### PR TITLE
Ft/update address script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 **/dist/**
 **/.env
 **/.env.*
+setup
+

--- a/apps/oracle/db/index.ts
+++ b/apps/oracle/db/index.ts
@@ -1,6 +1,7 @@
 import { drizzle, PostgresJsDatabase } from 'drizzle-orm/postgres-js';
 import postgres from 'postgres'
 import * as schema from './schema'
+import "dotenv/config";
 
 
 

--- a/apps/oracle/db/migrations/0004_wealthy_squadron_sinister.sql
+++ b/apps/oracle/db/migrations/0004_wealthy_squadron_sinister.sql
@@ -1,0 +1,7 @@
+ALTER TABLE "follow" DROP CONSTRAINT "follow_follower_id_account_id_fk";
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "follow" ADD CONSTRAINT "follow_follower_id_account_id_fk" FOREIGN KEY ("follower_id") REFERENCES "account"("id") ON DELETE no action ON UPDATE cascade;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;

--- a/apps/oracle/db/migrations/0005_classy_clint_barton.sql
+++ b/apps/oracle/db/migrations/0005_classy_clint_barton.sql
@@ -1,0 +1,7 @@
+ALTER TABLE "follow" DROP CONSTRAINT "follow_follower_id_account_id_fk";
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "follow" ADD CONSTRAINT "follow_follower_id_account_id_fk" FOREIGN KEY ("follower_id") REFERENCES "account"("id") ON DELETE no action ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;

--- a/apps/oracle/db/migrations/meta/0004_snapshot.json
+++ b/apps/oracle/db/migrations/meta/0004_snapshot.json
@@ -1,0 +1,630 @@
+{
+  "id": "e3b938e3-3704-443f-8550-ac24025ed286",
+  "prevId": "41137d94-2ccd-46da-be54-ba06d2d49576",
+  "version": "5",
+  "dialect": "pg",
+  "tables": {
+    "account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "object_address": {
+          "name": "object_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "follow": {
+      "name": "follow",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "follower_id": {
+          "name": "follower_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "following_id": {
+          "name": "following_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "follow_follower_id_account_id_fk": {
+          "name": "follow_follower_id_account_id_fk",
+          "tableFrom": "follow",
+          "tableTo": "account",
+          "columnsFrom": [
+            "follower_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        },
+        "follow_following_id_account_id_fk": {
+          "name": "follow_following_id_account_id_fk",
+          "tableFrom": "follow",
+          "tableTo": "account",
+          "columnsFrom": [
+            "following_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "publication": {
+      "name": "publication",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "creator_id": {
+          "name": "creator_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "type": {
+          "name": "type",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "publication_ref": {
+          "name": "publication_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "publication_creator_id_account_id_fk": {
+          "name": "publication_creator_id_account_id_fk",
+          "tableFrom": "publication",
+          "tableTo": "account",
+          "columnsFrom": [
+            "creator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "publication_parent_id_publication_id_fk": {
+          "name": "publication_parent_id_publication_id_fk",
+          "tableFrom": "publication",
+          "tableTo": "publication",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "reaction": {
+      "name": "reaction",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "publication_id": {
+          "name": "publication_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "creator_id": {
+          "name": "creator_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "reaction": {
+          "name": "reaction",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "reaction_publication_id_publication_id_fk": {
+          "name": "reaction_publication_id_publication_id_fk",
+          "tableFrom": "reaction",
+          "tableTo": "publication",
+          "columnsFrom": [
+            "publication_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "reaction_creator_id_account_id_fk": {
+          "name": "reaction_creator_id_account_id_fk",
+          "tableFrom": "reaction",
+          "tableTo": "account",
+          "columnsFrom": [
+            "creator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "delegate": {
+      "name": "delegate",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "delegate_owner_id_account_id_fk": {
+          "name": "delegate_owner_id_account_id_fk",
+          "tableFrom": "delegate",
+          "tableTo": "account",
+          "columnsFrom": [
+            "owner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "username": {
+      "name": "username",
+      "schema": "",
+      "columns": {
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "owner_address": {
+          "name": "owner_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_address": {
+          "name": "token_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "profile": {
+      "name": "profile",
+      "schema": "",
+      "columns": {
+        "creator": {
+          "name": "creator",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "pfp": {
+          "name": "pfp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "profile_creator_account_id_fk": {
+          "name": "profile_creator_account_id_fk",
+          "tableFrom": "profile",
+          "tableTo": "account",
+          "columnsFrom": [
+            "creator"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "communities": {
+      "name": "communities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "creator_address": {
+          "name": "creator_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_kid": {
+          "name": "user_kid",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "communities_user_kid_account_id_fk": {
+          "name": "communities_user_kid_account_id_fk",
+          "tableFrom": "communities",
+          "tableTo": "account",
+          "columnsFrom": [
+            "user_kid"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "communities_name_unique": {
+          "name": "communities_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      }
+    },
+    "community_posts": {
+      "name": "community_posts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "community_id": {
+          "name": "community_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_kid": {
+          "name": "user_kid",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "community_posts_community_id_communities_id_fk": {
+          "name": "community_posts_community_id_communities_id_fk",
+          "tableFrom": "community_posts",
+          "tableTo": "communities",
+          "columnsFrom": [
+            "community_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "community_posts_user_kid_account_id_fk": {
+          "name": "community_posts_user_kid_account_id_fk",
+          "tableFrom": "community_posts",
+          "tableTo": "account",
+          "columnsFrom": [
+            "user_kid"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "community_posts_post_id_publication_id_fk": {
+          "name": "community_posts_post_id_publication_id_fk",
+          "tableFrom": "community_posts",
+          "tableTo": "publication",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "membership": {
+      "name": "membership",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "community_id": {
+          "name": "community_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_kid": {
+          "name": "user_kid",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "type": {
+          "name": "type",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "membership_community_id_communities_id_fk": {
+          "name": "membership_community_id_communities_id_fk",
+          "tableFrom": "membership",
+          "tableTo": "communities",
+          "columnsFrom": [
+            "community_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "membership_user_kid_account_id_fk": {
+          "name": "membership_user_kid_account_id_fk",
+          "tableFrom": "membership",
+          "tableTo": "account",
+          "columnsFrom": [
+            "user_kid"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/oracle/db/migrations/meta/0005_snapshot.json
+++ b/apps/oracle/db/migrations/meta/0005_snapshot.json
@@ -1,0 +1,630 @@
+{
+  "id": "322e861a-05d5-48bf-8ba2-725ad86c416e",
+  "prevId": "e3b938e3-3704-443f-8550-ac24025ed286",
+  "version": "5",
+  "dialect": "pg",
+  "tables": {
+    "account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "object_address": {
+          "name": "object_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "follow": {
+      "name": "follow",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "follower_id": {
+          "name": "follower_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "following_id": {
+          "name": "following_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "follow_follower_id_account_id_fk": {
+          "name": "follow_follower_id_account_id_fk",
+          "tableFrom": "follow",
+          "tableTo": "account",
+          "columnsFrom": [
+            "follower_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "follow_following_id_account_id_fk": {
+          "name": "follow_following_id_account_id_fk",
+          "tableFrom": "follow",
+          "tableTo": "account",
+          "columnsFrom": [
+            "following_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "publication": {
+      "name": "publication",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "creator_id": {
+          "name": "creator_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "type": {
+          "name": "type",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "publication_ref": {
+          "name": "publication_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "publication_creator_id_account_id_fk": {
+          "name": "publication_creator_id_account_id_fk",
+          "tableFrom": "publication",
+          "tableTo": "account",
+          "columnsFrom": [
+            "creator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "publication_parent_id_publication_id_fk": {
+          "name": "publication_parent_id_publication_id_fk",
+          "tableFrom": "publication",
+          "tableTo": "publication",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "reaction": {
+      "name": "reaction",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "publication_id": {
+          "name": "publication_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "creator_id": {
+          "name": "creator_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "reaction": {
+          "name": "reaction",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "reaction_publication_id_publication_id_fk": {
+          "name": "reaction_publication_id_publication_id_fk",
+          "tableFrom": "reaction",
+          "tableTo": "publication",
+          "columnsFrom": [
+            "publication_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "reaction_creator_id_account_id_fk": {
+          "name": "reaction_creator_id_account_id_fk",
+          "tableFrom": "reaction",
+          "tableTo": "account",
+          "columnsFrom": [
+            "creator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "delegate": {
+      "name": "delegate",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "delegate_owner_id_account_id_fk": {
+          "name": "delegate_owner_id_account_id_fk",
+          "tableFrom": "delegate",
+          "tableTo": "account",
+          "columnsFrom": [
+            "owner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "username": {
+      "name": "username",
+      "schema": "",
+      "columns": {
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "owner_address": {
+          "name": "owner_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_address": {
+          "name": "token_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "profile": {
+      "name": "profile",
+      "schema": "",
+      "columns": {
+        "creator": {
+          "name": "creator",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "pfp": {
+          "name": "pfp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "profile_creator_account_id_fk": {
+          "name": "profile_creator_account_id_fk",
+          "tableFrom": "profile",
+          "tableTo": "account",
+          "columnsFrom": [
+            "creator"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "communities": {
+      "name": "communities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "creator_address": {
+          "name": "creator_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_kid": {
+          "name": "user_kid",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "communities_user_kid_account_id_fk": {
+          "name": "communities_user_kid_account_id_fk",
+          "tableFrom": "communities",
+          "tableTo": "account",
+          "columnsFrom": [
+            "user_kid"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "communities_name_unique": {
+          "name": "communities_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      }
+    },
+    "community_posts": {
+      "name": "community_posts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "community_id": {
+          "name": "community_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_kid": {
+          "name": "user_kid",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "community_posts_community_id_communities_id_fk": {
+          "name": "community_posts_community_id_communities_id_fk",
+          "tableFrom": "community_posts",
+          "tableTo": "communities",
+          "columnsFrom": [
+            "community_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "community_posts_user_kid_account_id_fk": {
+          "name": "community_posts_user_kid_account_id_fk",
+          "tableFrom": "community_posts",
+          "tableTo": "account",
+          "columnsFrom": [
+            "user_kid"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "community_posts_post_id_publication_id_fk": {
+          "name": "community_posts_post_id_publication_id_fk",
+          "tableFrom": "community_posts",
+          "tableTo": "publication",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "membership": {
+      "name": "membership",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "community_id": {
+          "name": "community_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_kid": {
+          "name": "user_kid",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "type": {
+          "name": "type",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "membership_community_id_communities_id_fk": {
+          "name": "membership_community_id_communities_id_fk",
+          "tableFrom": "membership",
+          "tableTo": "communities",
+          "columnsFrom": [
+            "community_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "membership_user_kid_account_id_fk": {
+          "name": "membership_user_kid_account_id_fk",
+          "tableFrom": "membership",
+          "tableTo": "account",
+          "columnsFrom": [
+            "user_kid"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/oracle/db/migrations/meta/_journal.json
+++ b/apps/oracle/db/migrations/meta/_journal.json
@@ -29,6 +29,20 @@
       "when": 1710680640026,
       "tag": "0003_fuzzy_celestials",
       "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "5",
+      "when": 1719298860254,
+      "tag": "0004_wealthy_squadron_sinister",
+      "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "5",
+      "when": 1719298909188,
+      "tag": "0005_classy_clint_barton",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/oracle/fill-test-values.ts
+++ b/apps/oracle/fill-test-values.ts
@@ -1,0 +1,114 @@
+import db from "./db";
+import { account, communities, delegate, username } from "./db/schema";
+
+async function fillTestValues() {
+    try {
+        // first account has short address and object address
+        // Second has only short address
+        // Third has only short object address
+        // the rest are good
+        await db.insert(account).values([{
+            id: 142,
+            address: "0x777b6eb4104e231694b2cff97d8316faa4513d2e5df7cde43d97f6a5b1932df",
+            object_address: "0x838db127fe05785814a9ed3defa6b3b1def1b129f67dd8758bfcf1f8e0621a1",
+            timestamp: new Date()
+        }, {
+            id: 143,
+            address: "0x777b6eb4104e231694b2cff97d8316faa4513d2e5df7cde43d97f6a5b1932df",
+            object_address: "0x395ddfe36477b72c08225c2d28d3e1670f7e7392d657263bc8fb0ea45d9214e7",
+            timestamp: new Date()
+        }, {
+            id: 144,
+            address: "0x7b7e5e26666fa82b9445ab6284a92883e0e4e3c453c9d5098115b2af75757fa9",
+            object_address: "0x1ed1178680dbbded9ebdd10b30f888778bcca8ca6a1d13bbb99ee4ca1ffb04e",
+            timestamp: new Date()
+        }, {
+            id: 145,
+            address: "0x7b7e5e26666fa82b9445ab6284a92883e0e4e3c453c9d5098115b2af75757fa9",
+            object_address: "0x395ddfe36477b72c08225c2d28d3e1670f7e7392d657263bc8fb0ea45d9214e7",
+            timestamp: new Date()
+        }]);
+
+        // First community has short creator_address
+        // Rest are good
+        await db.insert(communities).values([{
+            id: 100,
+            name: "origin",
+            description: "original ocmmunity",
+            image: "image.com",
+            creator_address: "0x777b6eb4104e231694b2cff97d8316faa4513d2e5df7cde43d97f6a5b1932df",
+            user_kid: 142,
+            timestamp: new Date(),
+            display_name: "origin"
+        }, {
+            id: 101,
+            name: "origin2",
+            description: "original ocmmunity2",
+            image: "image2.com",
+            creator_address: "0x7b7e5e26666fa82b9445ab6284a92883e0e4e3c453c9d5098115b2af75757fa9",
+            user_kid: 145,
+            timestamp: new Date(),
+            display_name: "origin2"
+        }, {
+            id: 102,
+            name: "origin3",
+            description: "original ocmmunity3",
+            image: "image3.com",
+            creator_address: "0x395ddfe36477b72c08225c2d28d3e1670f7e7392d657263bc8fb0ea45d9214e7",
+            user_kid: 144,
+            timestamp: new Date(),
+            display_name: "origin3"
+        }]);
+
+        // First delegate has short address, rest are good
+        await db.insert(delegate).values([{
+            id: 100,
+            address: "0x777b6eb4104e231694b2cff97d8316faa4513d2e5df7cde43d97f6a5b1932df",
+            owner_id: 142,
+            timestamp: new Date()
+        }, {
+            id: 101,
+            address: "0x63f06f04b0c72ba64a9ff70042983903c8ad8e8decaa60aebd8a1cbb02bed018",
+            owner_id: 143,
+            timestamp: new Date()
+        }, {
+            id: 102,
+            address: "0x376454caac95e72093ccd6ba128553906201c334bde2cb79145f1c6670515fa7",
+            owner_id: 144,
+            timestamp: new Date()
+        }]);
+
+        // First has short owner and token address
+        // Second has short owner address
+        // Third has short token address
+        // Final is good
+        await db.insert(username).values([{
+            username: "alice",
+            owner_address: "0x777b6eb4104e231694b2cff97d8316faa4513d2e5df7cde43d97f6a5b1932df",
+            token_address: "0xf3f042968993f4b166f236e8929724e011dab73f211ba1b811619940b36f63b",
+            timestamp: new Date()
+        }, {
+            username: "bob",
+            owner_address: "0x777b6eb4104e231694b2cff97d8316faa4513d2e5df7cde43d97f6a5b1932df",
+            token_address: "0x7018dced7ffe1da19b1229e4aeeb5db6d51efcb53c958a78e056fe12c40f3cfc",
+            timestamp: new Date()
+        }, {
+            username: "ted",
+            owner_address: "0x63f06f04b0c72ba64a9ff70042983903c8ad8e8decaa60aebd8a1cbb02bed018",
+            token_address: "0xf3f042968993f4b166f236e8929724e011dab73f211ba1b811619940b36f63b",
+            timestamp: new Date()
+        }, {
+            username: "karl",
+            owner_address: "0x7b7e5e26666fa82b9445ab6284a92883e0e4e3c453c9d5098115b2af75757fa9",
+            token_address: "0x7153cd74eaa5614ad4f51cfca4aa728276d6c172ea6e2a84bd534e2461ae0485",
+            timestamp: new Date()
+        }]);
+
+        console.log("Inputting test values done!");
+    } catch(err) {
+        console.log(err);
+        throw "Could Not Create Test Data";
+    }
+}
+
+fillTestValues();

--- a/apps/oracle/select-rows.ts
+++ b/apps/oracle/select-rows.ts
@@ -1,0 +1,93 @@
+import db from "./db";
+import { account, communities, delegate, sql, username } from "./src";
+
+const addressSize = 66;
+
+export const addressTransfomer = (p: string) => {
+    const address = p
+    // Check if address is less than 66 char long
+    if (typeof p == 'string' && p.length < addressSize) {
+        // Add the necessary padding
+        let paddingAmount = addressSize - p.length;
+
+        // Add padding
+        let padding = "0".repeat(paddingAmount);
+        const newAddress = p.replace("0x", "0x" + padding);
+        return newAddress;
+    }
+    return address
+}
+
+export async function selectAccountsRows(): Promise<{address: string, object_address: string}[]> {
+    try {
+        let results = await db.select({
+            address: account.address,
+            object_address: account.object_address
+        }).from(account).where(sql`length(address) < ${addressSize} OR length(object_address) < ${addressSize}`);
+
+        let addresses: {address: string, object_address: string}[] = [];
+        for (let i = 0; i < results.length; i++) {
+            let res = results[i];
+            addresses.push({address: res['address'], object_address: res['object_address']});
+        }
+
+        return addresses;
+    } catch(err) {
+        throw "Could Not Get Accounts";
+    }
+}
+
+export async function selectCommunitiesRows(): Promise<string[]> {
+    try {
+        let results = await db.select({
+            creator_address: communities.creator_address
+        }).from(communities).where(sql`length(creator_address) < ${addressSize}`);
+
+        let addresses = [];
+        for (let i = 0; i < results.length; i++) {
+            let res = results[i];
+            addresses.push(res['creator_address']);
+        }
+
+        return addresses;
+    } catch(err) {
+        throw "Could Not Get Communities";
+    }
+}
+
+export async function selectDelegatesRows(): Promise<string[]> {
+    try {
+        let results = await db.select({
+            address: delegate.address
+        }).from(delegate).where(sql`length(address) < ${addressSize}`);
+
+        let addresses = [];
+        for (let i = 0; i < results.length; i++) {
+            let res = results[i];
+            addresses.push(res['address']);
+        }
+
+        return addresses;
+    } catch(err) {
+        throw "Could Not Get Delegates";
+    }
+}
+
+export async function selectUsernameRows(): Promise<{owner_address: string; token_address: string}[]> {
+    try {
+        let results = await db.select({
+            owner_address: username.owner_address,
+            token_address: username.token_address
+        }).from(username).where(sql`length(owner_address) < ${addressSize} OR length(token_address) < ${addressSize}`);
+
+        let addresses:{owner_address: string; token_address: string}[] = [];
+        for (let i = 0; i < results.length; i++) {
+            let res = results[i];
+            addresses.push({owner_address: res['owner_address'], token_address: res['token_address']});
+        }
+
+        return addresses;
+    } catch(err) {
+        throw "Could Not Get Usernames";
+    }
+}

--- a/apps/oracle/update-tables.ts
+++ b/apps/oracle/update-tables.ts
@@ -1,0 +1,101 @@
+import db from "./db";
+import { addressTransfomer, selectAccountsRows, selectCommunitiesRows, selectDelegatesRows, selectUsernameRows } from "./select-rows";
+import { account, communities, ConsoleLogWriter, delegate, sql, username } from "./src";
+
+async function updateTables() {
+    try {
+        await updateAccounts();
+        await updateCommunities();
+        await updateDelegates();
+        await updateUsernames();
+
+        console.log("Update Tables Complete");
+    } catch(err) {
+        console.log("Could Not Update tables", err);
+        throw "Could not update tables"
+    }
+}
+
+async function updateAccounts() {
+    try {
+        // Get accounts to change
+        let addresses = await selectAccountsRows();
+
+        // Log accounts that are to be updated
+        console.log("Accounts to be updated", addresses);
+
+        for (let i = 0; i < addresses.length; i++) {
+            var addr = addresses[i];
+            var goodAddr = addressTransfomer(addr['address']);
+            var goodObjAdr = addressTransfomer(addr['object_address'])
+
+            await db.update(account).set({address: goodAddr, object_address: goodObjAdr}).where(sql`address = ${addr['address']} AND object_address = ${addr['object_address']}`);
+        }
+    } catch(err) {
+        console.log("Could Not Update Accounts", err);
+        throw "Could Not Update Accounts";
+    }
+}
+
+async function updateCommunities() {
+    try {
+        // Get accounts to change
+        let addresses = await selectCommunitiesRows();
+
+        // Log communities to be changed
+        console.log("Communities to be changed have the following addresses", addresses);
+
+        for (let i = 0; i < addresses.length; i++) {
+            var addr = addresses[i];
+            var goodAddr = addressTransfomer(addr);
+
+            await db.update(communities).set({creator_address: goodAddr}).where(sql`creator_address = ${addr}`);
+        }
+    } catch(err) {
+        console.log("Could Not Update Communities", err);
+        throw "Could Not Update Communities";
+    }
+}
+
+async function updateDelegates() {
+    try {
+        // Get accounts to change
+        let addresses = await selectDelegatesRows();
+
+        // Log communities to be changed
+        console.log("Delegates to be changed have the following addresses", addresses);
+
+        for (let i = 0; i < addresses.length; i++) {
+            var addr = addresses[i];
+            var goodAddr = addressTransfomer(addr);
+
+            await db.update(delegate).set({address: goodAddr}).where(sql`address = ${addr}`);
+        }
+    } catch(err) {
+        console.log("Could Not Update Communities", err);
+        throw "Could Not Update Communities";
+    }
+}
+
+async function updateUsernames() {
+    try {
+        // Get accounts to change
+        let addresses = await selectUsernameRows();
+
+        // Log communities to be changed
+        console.log("Usernames to be changed have the following addresses", addresses);
+
+        for (let i = 0; i < addresses.length; i++) {
+            var addr = addresses[i];
+            var goodOwnerAddr = addressTransfomer(addr['owner_address']);
+            var goodTokenAddr = addressTransfomer(addr['token_address']);
+
+            await db.update(username).set({owner_address: goodOwnerAddr, token_address: goodTokenAddr}).where(sql`owner_address = ${addr['owner_address']} AND token_address = ${addr['token_address']}`);
+        }
+    } catch(err) {
+        console.log("Could Not Update Usernames", err);
+        throw "Could Not Update Usernames";
+    }
+}
+
+updateTables()

--- a/apps/reader/schema.ts
+++ b/apps/reader/schema.ts
@@ -1,11 +1,18 @@
 import { z } from "zod";
 
+const addressSize = 66;
 const addressTransfomer = (p: string) => {
     const address = p
-    // if (typeof p == 'string' && p.length == 65) {
-    //     const newAddress = p.replace("0x", "0x0")
-    //     return newAddress
-    // }
+    // Check if address is less than 66 char long
+    if (typeof p == 'string' && p.length < addressSize) {
+        // Add the necessary padding
+        let paddingAmount = addressSize - p.length;
+
+        // Add padding
+        let padding = "0".repeat(paddingAmount);
+        const newAddress = p.replace("0x", "0x" + padding);
+        return newAddress;
+    }
     return address
 }
 


### PR DESCRIPTION
- Contains scripts meant to update the lagoon tables
- I had initially set the tables to cascade on update but later on realized that it wasn't necessary, it generated some migrations so decided to push them incase they were needed. I tried deleting the migrations but it caused issues on my end
- I have included a way to test. To test follow the following instructions
1. Ensure PG_CONNECTION_STRING is set to connection string of local postgres instance
2. Run the migrations
3. Run the fill-test-values script to populate table with test values (the file includes details of what addresses are short and can indicate what rows to look out for in results)
4. Run the update-tables script to update the tables
5. View the tables to see if rows were changed

To run the script on tesnet or prod change your PG_CONNECTION_STRING env variable to that of testnet or prod then run the update-tables script